### PR TITLE
Update plugin id and rename UI title

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"id": "obsidian-local-rest-api",
-	"name": "Local REST API",
+        "id": "obsidian-chatgpt-bridge",
+        "name": "LLM Bridges",
 	"version": "3.2.0",
 	"minAppVersion": "0.12.0",
 	"description": "Get, change or otherwise interact with your notes in Obsidian via a REST API.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "obsidian-local-rest-api",
+  "name": "obsidian-chatgpt-bridge",
   "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "obsidian-local-rest-api",
+      "name": "obsidian-chatgpt-bridge",
       "version": "3.2.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "obsidian-local-rest-api",
+  "name": "obsidian-chatgpt-bridge",
   "version": "3.2.0",
   "description": "Get, change or otherwise interact with your notes in Obsidian via a REST API.",
   "main": "main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,7 +147,7 @@ export default class LocalRestApi extends Plugin {
 
     this.refreshServerState();
 
-    this.app.workspace.trigger("obsidian-local-rest-api:loaded");
+    this.app.workspace.trigger("obsidian-chatgpt-bridge:loaded");
   }
 
   getPublicApi(pluginManifest: PluginManifest): LocalRestApiPublicApi {
@@ -257,8 +257,8 @@ class LocalRestApiSettingTab extends PluginSettingTab {
       !getCertificateIsUptoStandards(parsedCertificate);
 
     containerEl.empty();
-    containerEl.classList.add("obsidian-local-rest-api-settings");
-    containerEl.createEl("h2", { text: "Local REST API" });
+    containerEl.classList.add("obsidian-chatgpt-bridge-settings");
+    containerEl.createEl("h2", { text: "LLM Bridges" });
     containerEl.createEl("h3", { text: "How to Access" });
 
     const apiKeyDiv = containerEl.createEl("div");
@@ -266,7 +266,7 @@ class LocalRestApiSettingTab extends PluginSettingTab {
 
     const availableApis = apiKeyDiv.createEl("p");
     availableApis.innerHTML = `
-      You can access Obsidian Local REST API via the following URLs:
+      You can access LLM Bridges via the following URLs:
     `;
 
     const connectionUrls = apiKeyDiv.createEl("table", { cls: "api-urls" });
@@ -407,7 +407,7 @@ class LocalRestApiSettingTab extends PluginSettingTab {
       shouldRegenerateCertificateDiv.innerHTML = `
         <b>You should re-generate your certificate!</b>
         Your certificate was generated using earlier standards than
-        are currently used by Obsidian Local REST API. Some systems
+        are currently used by LLM Bridges. Some systems
         or tools may not accept your certificate with its current
         configuration, and re-generating your certificate may
         improve compatibility with such tools.  To re-generate your
@@ -673,7 +673,7 @@ export const getAPI = (
   app: App,
   manifest: PluginManifest
 ): LocalRestApiPublicApi | undefined => {
-  const plugin = app.plugins.plugins["obsidian-local-rest-api"];
+  const plugin = app.plugins.plugins["obsidian-chatgpt-bridge"];
   if (plugin) {
     return (plugin as unknown as LocalRestApi).getPublicApi(manifest);
   }

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,9 @@
 /* Sets all the text color to red! */
 
-div.obsidian-local-rest-api-settings div.api-key-display {
+div.obsidian-chatgpt-bridge-settings div.api-key-display {
   margin-bottom: 20px;
 }
-div.obsidian-local-rest-api-settings div.api-key-display pre {
+div.obsidian-chatgpt-bridge-settings div.api-key-display pre {
   font-size: 0.8em;
   padding: 10px 20px;
   background-color: var(--background-modifier-cover);
@@ -11,37 +11,37 @@ div.obsidian-local-rest-api-settings div.api-key-display pre {
   user-select: all;
 }
 
-div.obsidian-local-rest-api-settings div.setting-item-control {
+div.obsidian-chatgpt-bridge-settings div.setting-item-control {
   min-width: 50%;
 }
 
-div.obsidian-local-rest-api-settings textarea {
+div.obsidian-chatgpt-bridge-settings textarea {
   width: 100%;
 }
 
-div.obsidian-local-rest-api-settings div.certificate-expired {
+div.obsidian-chatgpt-bridge-settings div.certificate-expired {
   padding: 10px 20px;
   border: 2px solid #ff0000;
 }
 
-div.obsidian-local-rest-api-settings div.certificate-expiring-soon {
+div.obsidian-chatgpt-bridge-settings div.certificate-expiring-soon {
   padding: 10px 20px;
   border: 2px solid #ffff00;
 }
 
-div.obsidian-local-rest-api-settings div.certificate-regeneration-recommended {
+div.obsidian-chatgpt-bridge-settings div.certificate-regeneration-recommended {
   padding: 10px 20px;
   border: 2px solid #ffff00;
 }
 
-div.obsidian-local-rest-api-settings table.api-urls tr {
+div.obsidian-chatgpt-bridge-settings table.api-urls tr {
   width: 100%;
 }
 
-div.obsidian-local-rest-api-settings table.api-urls th, div.obsidian-local-rest-api-settings table.api-urls td {
+div.obsidian-chatgpt-bridge-settings table.api-urls th, div.obsidian-chatgpt-bridge-settings table.api-urls td {
   padding: 5px 25px;
 }
 
-div.obsidian-local-rest-api-settings table.api-urls tr.disabled td.name, div.obsidian-local-rest-api-settings table.api-urls tr.disabled td.url {
+div.obsidian-chatgpt-bridge-settings table.api-urls tr.disabled td.name, div.obsidian-chatgpt-bridge-settings table.api-urls tr.disabled td.url {
   text-decoration: line-through;
 }


### PR DESCRIPTION
## Summary
- rename plugin ID to `obsidian-chatgpt-bridge`
- update displayed title to **LLM Bridges** and adjust CSS and event strings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685435c333f08323ac994e1709e20a68