### PR TITLE
Update plugin id and fix README

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"id": "obsidian-local-rest-api",
+        "id": "obsidian-llm-bridges",
 	"name": "LLM Bridges",
 	"version": "3.2.0",
 	"minAppVersion": "0.12.0",


### PR DESCRIPTION
## Summary
- set plugin id to `obsidian-llm-bridges`
- reverted README lines per inline feedback

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857cb86a28483238524f065cbb713b3